### PR TITLE
Ban certain typing-related APIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,11 +67,27 @@ select = [
     "E",  # all pyflakes rules
     "F",  # all pycodestyle rules
     "I",  # all isort rules
+    "TID251",  # banned imports, see below
     # "PLC0415",  # disallow imports outside module top-level scope
 ]
 unfixable = [
     "F401",  # unused imports
 ]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.Callable".msg = "Use `collections.abc.Callable` instead of `typing.Callable`"
+"typing.DefaultDict".msg = "Use `collections.defaultdict` instead of `typing.DefaultDict`"
+"typing.Dict".msg = "Use the standard library `dict` instead of `typing.Dict`"
+"typing.Iterable".msg = "Use `collections.abc.Iterable` instead of `typing.Iterable`"
+"typing.Iterator".msg = "Use `collections.abc.Iterator` instead of `typing.Iterator`"
+"typing.List".msg = "Use the standard library `list` instead of `typing.List`"
+"typing.Optional".msg = "Use the standard library `| None` syntax instead of `typing.Optional`"
+"typing.Sequence".msg = "Use `collections.abc.Sequence` instead of `typing.Sequence`"
+"typing.Set".msg = "Use the standard library `set` instead of `typing.Set`"
+"typing.Tuple".msg = "Use the standard library `tuple` instead of `typing.Tuple`"
+"typing.Type".msg = "Use the standard library `type` instead of `typing.Type`"
+"typing.Union".msg = "Use the standard library `|` syntax instead of `typing.Union`"
+"typing_extensions.Self".msg = "Use `typing.Self` instead of `typing_extensions.Self`"
 
 [tool.mypy]
 plugins = ["numpy.typing.mypy_plugin"]

--- a/src/frheed/widgets/camera_widget.py
+++ b/src/frheed/widgets/camera_widget.py
@@ -7,7 +7,6 @@ import logging
 import os
 import time
 from datetime import datetime
-from typing import Optional, Union
 
 import cv2
 import numpy as np
@@ -67,7 +66,7 @@ class VideoWidget(QWidget):
     _min_h = 348
     _max_w = MAX_W
 
-    def __init__(self, camera: Union[FlirCamera, UsbCamera], parent=None, zoomable: bool = True):
+    def __init__(self, camera: FlirCamera | UsbCamera, parent=None, zoomable: bool = True) -> None:
         super().__init__(parent)
 
         # Store colormap
@@ -77,7 +76,7 @@ class VideoWidget(QWidget):
         self._zoomable = zoomable
 
         # Video writer for saving video
-        self._writer: Optional[cv2.VideoWriter] = None
+        self._writer: cv2.VideoWriter | None = None
 
         # Store camera reference and start the camera
         self.set_camera(camera)
@@ -174,8 +173,8 @@ class VideoWidget(QWidget):
         self.frame_changed.connect(self.status_bar.frame_changed)
 
         # Attributes to be assigned later
-        self.frame: Union[np.ndarray, None] = None
-        self.raw_frame: Union[np.ndarray, None] = None
+        self.frame: np.ndarray | None = None
+        self.raw_frame: np.ndarray | None = None
         self.region_data: dict = {}
         self.analyze_frames = True
 
@@ -358,11 +357,11 @@ class VideoWidget(QWidget):
         self.display.force_resize()
 
     @property
-    def camera(self) -> Union[FlirCamera, UsbCamera]:
+    def camera(self) -> FlirCamera | UsbCamera:
         return self._camera
 
     @camera.setter
-    def camera(self, camera: Union[FlirCamera, UsbCamera]) -> None:
+    def camera(self, camera: FlirCamera | UsbCamera) -> None:
         # Cannot set camera while recording
         if self._writer is not None:
             return QMessageBox.warning(
@@ -407,7 +406,7 @@ class VideoWidget(QWidget):
     def make_camera_settings_widget(self) -> None:
         self.settings_widget = CameraSettingsWidget(self)
 
-    def set_camera(self, camera: Union[FlirCamera, UsbCamera]) -> None:
+    def set_camera(self, camera: FlirCamera | UsbCamera) -> None:
         """Set the camera to use as capture device for the display.
 
         Args:
@@ -507,7 +506,7 @@ class CameraDisplay(QWidget):
         self.canvas.raise_()
 
     @property
-    def raw_frame(self) -> Union[None, np.ndarray]:
+    def raw_frame(self) -> np.ndarray | None:
         return self._parent.raw_frame
 
     @property
@@ -552,7 +551,7 @@ class CameraDisplay(QWidget):
             self.label.pixmap().scaled(self.sizeHint(), Qt.KeepAspectRatio, Qt.SmoothTransformation)
         )
 
-    def parent(self) -> Union[None, VideoWidget]:
+    def parent(self) -> VideoWidget | None:
         return self._parent or super().parent()
 
 
@@ -653,7 +652,7 @@ class CameraSettingsWidget(QWidget):
         self.setVisible(False)
 
     @property
-    def camera(self) -> Union[FlirCamera, UsbCamera, None]:
+    def camera(self) -> FlirCamera | UsbCamera | None:
         return getattr(self._parent, "camera", None)
 
     @property
@@ -933,7 +932,7 @@ class CameraSettingsWidget(QWidget):
             getattr(self.widget, sig).connect(self.change_setting)
             self._connected = True
 
-        def set_value(self, value: Union[bool, str, float]) -> None:
+        def set_value(self, value: bool | str | float) -> None:
             if isinstance(self.widget, (QDoubleSpinBox, DoubleSlider)):
                 self.widget.setValue(value)
 
@@ -946,7 +945,7 @@ class CameraSettingsWidget(QWidget):
             elif isinstance(self.widget, QLineEdit):
                 self.widget.setText(str(value))
 
-        def get_value(self) -> Union[bool, str, float]:
+        def get_value(self) -> bool | str | float:
             """Get the current value of the setting"""
             if isinstance(self.widget, (QDoubleSpinBox, DoubleSlider)):
                 return self.widget.value()
@@ -960,7 +959,7 @@ class CameraSettingsWidget(QWidget):
             elif isinstance(self.widget, QCheckBox):
                 return self.widget.isChecked()
 
-        def change_setting(self, value: Union[bool, str, float]) -> None:
+        def change_setting(self, value: bool | str | float) -> None:
             # Mark the SettingsWidget as not saved
             self._parent.saved = False
 
@@ -1023,7 +1022,7 @@ class CameraStatusBar(QStatusBar):
         #                    )
 
     @property
-    def camera(self) -> Union[FlirCamera, UsbCamera, None]:
+    def camera(self) -> FlirCamera | UsbCamera | None:
         return getattr(self._parent, "camera", None)
 
     @property
@@ -1065,13 +1064,13 @@ class Worker(QObject):
         self._parent = parent
         self._running = False
 
-    def camera(self) -> Union[FlirCamera, UsbCamera, None]:
+    def camera(self) -> FlirCamera | UsbCamera | None:
         return getattr(self._parent, "camera", None)
 
-    def display(self) -> Union[CameraDisplay, None]:
+    def display(self) -> CameraDisplay | None:
         return getattr(self._parent, "display", None)
 
-    def canvas(self) -> Union[CanvasWidget, None]:
+    def canvas(self) -> CanvasWidget | None:
         return getattr(self.display(), "canvas", None)
 
     def running(self) -> bool:
@@ -1118,11 +1117,11 @@ class AnalysisWorker(Worker):
     start_time = None
 
     @property
-    def shapes(self) -> Union[list, tuple]:
+    def shapes(self) -> list | tuple:
         return getattr(self.canvas(), "shapes", ())
 
     @property
-    def raw_frame(self) -> Union[np.ndarray, None]:
+    def raw_frame(self) -> np.ndarray | None:
         return getattr(self.camera(), "raw_frame", None)
 
     @pyqtSlot(np.ndarray)

--- a/src/frheed/widgets/canvas_widget.py
+++ b/src/frheed/widgets/canvas_widget.py
@@ -2,7 +2,7 @@
 PyQt widgets for drawing shapes.
 """
 
-from typing import List, Optional, Union
+from __future__ import annotations
 
 import numpy as np
 from PyQt5.QtCore import QEvent, QLine, QPoint, QRect, QSize, Qt, pyqtSignal, pyqtSlot
@@ -112,18 +112,18 @@ class CanvasWidget(QLabel):
 
         # Attributes to be assigned later
         self._drawing: bool = False
-        self._draw_start_pos: Optional[QPoint] = None
+        self._draw_start_pos: QPoint | None = None
 
         self._resizing: bool = False
-        self._resizing_from: Optional[str] = None
+        self._resizing_from: str | None = None
 
         self._moving: bool = False
-        self._move_start_pos: Optional[QPoint] = None
+        self._move_start_pos: QPoint | None = None
 
-        self._shapes: List[CanvasShape] = []
-        self._active_shape: Optional[CanvasShape] = None
+        self._shapes: list[CanvasShape] = []
+        self._active_shape: CanvasShape | None = None
 
-        self._pressed_buttons: List[int] = []
+        self._pressed_buttons: list[int] = []
 
         # Connect signals
         self.customContextMenuRequested.connect(self.menu_requested)
@@ -323,7 +323,7 @@ class CanvasWidget(QLabel):
         self._resizing_from = None
 
     @property
-    def resizing_from(self) -> Union[str, None]:
+    def resizing_from(self) -> str | None:
         return self._resizing_from
 
     @property
@@ -341,21 +341,21 @@ class CanvasWidget(QLabel):
             self.app.restoreOverrideCursor()
 
     @property
-    def shapes(self) -> List["CanvasShape"]:
+    def shapes(self) -> list[CanvasShape]:
         return self._shapes
 
     @shapes.setter
-    def shapes(self, shapes: List) -> None:
+    def shapes(self, shapes: list) -> None:
         self._shapes = shapes
         self.active_shape = None
         self.draw()
 
     @property
-    def active_shape(self) -> "CanvasShape":
+    def active_shape(self) -> CanvasShape:
         return self._active_shape
 
     @active_shape.setter
-    def active_shape(self, shape: "CanvasShape") -> None:
+    def active_shape(self, shape: CanvasShape) -> None:
         self._active_shape = shape
 
         # Deactivate other shapes so only one can be active at once
@@ -467,8 +467,8 @@ class CanvasShape(QRect):
         self._kind = SHAPE_TYPES[0]
         self._linewidth: int = DEFAULT_LINEWIDTH
         self._color: str = DEFAULT_COLOR
-        self._color_name: Optional[str] = None
-        self._canvas: Optional[CanvasWidget] = None
+        self._color_name: str | None = None
+        self._canvas: CanvasWidget | None = None
 
         # Store floating point coords for resizing precision
         self.float_coords = super().getCoords()
@@ -526,11 +526,11 @@ class CanvasShape(QRect):
         self.update()
 
     @property
-    def color(self) -> Union[QColor, None]:
+    def color(self) -> QColor | None:
         return self._color
 
     @color.setter
-    def color(self, color: Union[str, tuple, QColor]) -> None:
+    def color(self, color: str | tuple | QColor) -> None:
         self._color = get_qcolor(color)
 
     @property
@@ -538,7 +538,7 @@ class CanvasShape(QRect):
         return self.color.name()
 
     @property
-    def canvas(self) -> Union[CanvasWidget, None]:
+    def canvas(self) -> CanvasWidget | None:
         return self._canvas
 
     @canvas.setter
@@ -687,11 +687,11 @@ class CanvasShape(QRect):
         """Check if a QPoint is near any border of the shape"""
         return any(getattr(self, f"near_{reg}")(p) for reg in _SHAPE_REGIONS)
 
-    def nearby_regions(self, p: QPoint) -> List[str]:
+    def nearby_regions(self, p: QPoint) -> list[str]:
         """Get list of regions that are near a point"""
         return [r for r in _SHAPE_REGIONS if getattr(self, f"near_{r}")(p)]
 
-    def nearest_region(self, p: QPoint) -> Union[str, None]:
+    def nearest_region(self, p: QPoint) -> str | None:
         """Determine which region of the shape is closest to the point"""
 
         # Get list of nearby regions
@@ -853,8 +853,8 @@ class CanvasLine(QLine):
         # Attributes to be assigned later
         self._linewidth: int = DEFAULT_LINEWIDTH
         self._color: str = DEFAULT_COLOR
-        self._color_name: Optional[str] = None
-        self._canvas: Optional[CanvasWidget] = None
+        self._color_name: str | None = None
+        self._canvas: CanvasWidget | None = None
 
         # Store floating point coords for resizing precision
         self.float_coords = self.getCoords()
@@ -919,11 +919,11 @@ class CanvasLine(QLine):
         self._canvas._shapes.append(self)
 
     @property
-    def color(self) -> Union[QColor, None]:
+    def color(self) -> QColor | None:
         return self._color
 
     @color.setter
-    def color(self, color: Union[str, tuple, QColor]) -> None:
+    def color(self, color: str | tuple | QColor) -> None:
         self._color = get_qcolor(color)
 
     @property
@@ -977,7 +977,7 @@ class CanvasLine(QLine):
         """Get a list of regions that are near a point"""
         return [r for r in _LINE_REGIONS if getattr(self, f"near_{r}")(p)]
 
-    def nearest_region(self, p: QPoint) -> Union[str, None]:
+    def nearest_region(self, p: QPoint) -> str | None:
         """Determine which region of the line is closest to the point"""
 
         # Get list of nearby regions

--- a/src/frheed/widgets/common_widgets.py
+++ b/src/frheed/widgets/common_widgets.py
@@ -3,7 +3,6 @@ Commonly used subclassed PyQt5 widgets.
 """
 
 import math
-from typing import Optional, Union
 
 from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
 from PyQt5.QtGui import QFontMetrics
@@ -17,9 +16,7 @@ class DoubleSlider(QSlider):
 
     doubleValueChanged = pyqtSignal(float)
 
-    def __init__(
-        self, decimals: int, log: bool = False, base: Union[float, int] = 1.5, parent=None
-    ):
+    def __init__(self, decimals: int, log: bool = False, base: float | int = 1.5, parent=None):
         super().__init__(parent)
 
         # Validate input
@@ -66,35 +63,35 @@ class DoubleSlider(QSlider):
     def minimum(self) -> float:
         return getattr(self, "_minimum", self._to_float(super().minimum()))
 
-    def setMinimum(self, value: Union[float, int]) -> None:
+    def setMinimum(self, value: float) -> None:
         self._minimum = value
         super().setMinimum(self._to_int(value))
 
     def maximum(self) -> float:
         return getattr(self, "_maximum", self._to_float(super().maximum()))
 
-    def setMaximum(self, value: Union[float, int]) -> None:
+    def setMaximum(self, value: float) -> None:
         self._maximum = value
         super().setMaximum(self._to_int(value))
 
-    def setSingleStep(self, value: Union[float, int]) -> None:
+    def setSingleStep(self, value: float) -> None:
         super().setSingleStep(self._to_int(value))
 
     def singleStep(self) -> None:
         return self._to_float(super().singleStep())
 
-    def setValue(self, value: Union[float, int]) -> None:
+    def setValue(self, value: float) -> None:
         super().setValue(self._to_int(value))
 
-    def setTickInterval(self, value: Union[float, int]) -> None:
+    def setTickInterval(self, value: float) -> None:
         super().setTickInterval(self._to_int(value))
 
-    def _to_int(self, value: Union[int, float]) -> int:
+    def _to_int(self, value: float) -> int:
         if self.isLog():
             return int(round(math.log((value / self._multiplier), self.base())))
         return int(round(value / self._multiplier))
 
-    def _to_float(self, value: Union[int, float]) -> float:
+    def _to_float(self, value: float) -> float:
         if self.isLog():
             return float((self.base() ** value) * self._multiplier)
         return float(value * self._multiplier)
@@ -106,10 +103,10 @@ class SliderLabel(QLabel):
     def __init__(
         self,
         slider: QSlider,
-        name: Optional[str] = None,
-        unit: Optional[str] = None,
-        precision: Optional[int] = None,
-        pad: Optional[int] = 8,
+        name: str | None = None,
+        unit: str | None = None,
+        precision: int | None = None,
+        pad: int | None = 8,
     ):
         super().__init__(slider.parent())
 
@@ -184,7 +181,7 @@ class VSpacer(QSpacerItem):
 
 
 class VisibleSplitter(QSplitter):
-    def __init__(self, color: str, hover_color: Optional[str] = None, *args, **kwargs):
+    def __init__(self, color: str, hover_color: str | None = None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         style = (
             self.styleSheet()
@@ -204,7 +201,3 @@ class VisibleSplitter(QSplitter):
                                 """
         )
         self.setStyleSheet(style)
-
-
-if __name__ == "__main__":
-    pass

--- a/src/frheed/widgets/plot_widgets.py
+++ b/src/frheed/widgets/plot_widgets.py
@@ -3,7 +3,6 @@ Widgets for plotting data in PyQt.
 """
 
 import logging
-from typing import Optional, Union
 
 import numpy as np
 import pyqtgraph as pg  # import *after* PyQt5
@@ -83,8 +82,8 @@ class PlotWidget(QWidget):
         self,
         parent: QWidget = None,
         popup: bool = False,
-        name: Optional[str] = None,
-        title: Optional[str] = None,
+        name: str | None = None,
+        title: str | None = None,
         show_menubar: bool = True,
     ):
         super().__init__(parent)
@@ -182,13 +181,13 @@ class PlotWidget(QWidget):
     def axes(self) -> list:
         return [getattr(self, ax) for ax in _PG_AXES]
 
-    def get_curve(self, color: Union[QColor, str, tuple]) -> pg.PlotCurveItem:
+    def get_curve(self, color: QColor | str | tuple) -> pg.PlotCurveItem:
         """Get an existing plot item."""
         color = utils.get_qcolor(color)
         return self.plot_items.get(color.name())
 
     @pyqtSlot(str)
-    def add_curve(self, color: Union[QColor, str, tuple]) -> pg.PlotCurveItem:
+    def add_curve(self, color: QColor | str | tuple) -> pg.PlotCurveItem:
         """Add a curve to the plot."""
         # Raise error if curve already exists
         color = utils.get_qcolor(color)
@@ -211,7 +210,7 @@ class PlotWidget(QWidget):
         return curve
 
     @pyqtSlot(str)
-    def get_or_add_curve(self, color: Union[QColor, str, tuple]) -> pg.PlotCurveItem:
+    def get_or_add_curve(self, color: QColor | str | tuple) -> pg.PlotCurveItem:
         """Get a curve or add it if it doesn't exist."""
         # Return curve if it already exists
         color = utils.get_qcolor(color)
@@ -222,7 +221,7 @@ class PlotWidget(QWidget):
         return self.add_curve(color)
 
     @pyqtSlot(str)
-    def remove_curve(self, color: Union[QColor, str, tuple]) -> None:
+    def remove_curve(self, color: QColor | str | tuple) -> None:
         """Remove a curve from the plot."""
         # Remove the curve from the plot
         color = utils.get_qcolor(color)
@@ -296,7 +295,7 @@ class PlotWidget(QWidget):
         # Emit curve_toggled signal
         self.curve_toggled.emit(color, visible) if not block_signal else None
 
-    def _get_menu_action(self, color: str) -> Union[QAction, None]:
+    def _get_menu_action(self, color: str) -> QAction | None:
         return next((i for i in self.curve_menu.actions() if i.text() == color), None)
 
 
@@ -305,8 +304,8 @@ class LinePlotWidget(PlotWidget):
         self,
         parent: PlotWidget,
         popup: bool = False,
-        name: Optional[str] = None,
-        title: Optional[str] = None,
+        name: str | None = None,
+        title: str | None = None,
         show_menubar: bool = True,
     ) -> None:
         super().__init__(
@@ -402,11 +401,11 @@ class FFTPlotWidget(PlotWidget):
         self,
         parent: PlotWidget,
         popup: bool = False,
-        name: Optional[str] = None,
-        title: Optional[str] = None,
+        name: str | None = None,
+        title: str | None = None,
         show_menubar: bool = True,
         autofind_peaks: bool = True,
-        low_freq_cutoff: Optional[float] = _MIN_FFT_PEAK_POS,
+        low_freq_cutoff: float | None = _MIN_FFT_PEAK_POS,
     ) -> None:
         super().__init__(
             parent=parent, popup=popup, name=name, title=title, show_menubar=show_menubar
@@ -472,7 +471,7 @@ class FFTPlotWidget(PlotWidget):
         """Show/hide lines for a particular curve."""
         [line.setVisible(visible) for line in self.vlines.get(color, [])]
 
-    def detect_and_show_peaks(self, x: list, y: list, color: Optional[str] = None) -> None:
+    def detect_and_show_peaks(self, x: list, y: list, color: str | None = None) -> None:
         # Find peaks
         peak_positions = detect_peaks(x, y, _MIN_FFT_PEAK_POS)
         if peak_positions is None:
@@ -503,8 +502,8 @@ class LineProfileWidget(PlotWidget):
         self,
         parent: FFTPlotWidget,
         popup: bool = False,
-        name: Optional[str] = None,
-        title: Optional[str] = None,
+        name: str | None = None,
+        title: str | None = None,
         show_menubar: bool = True,
     ) -> None:
         super().__init__(
@@ -523,8 +522,8 @@ class LineScanPlotWidget(PlotWidget):
         self,
         parent: FFTPlotWidget,
         popup: bool = False,
-        name: Optional[str] = None,
-        title: Optional[str] = None,
+        name: str | None = None,
+        title: str | None = None,
         show_menubar: bool = True,
     ) -> None:
         super().__init__(
@@ -537,14 +536,11 @@ class LineScanPlotWidget(PlotWidget):
 
         # Image placeholders
         # TODO: Handle line scans from multiple different lines
-        self._image: Optional[np.ndarray] = None
-        self._pixmap_item: Optional[QGraphicsPixmapItem] = None
-
-        # TESTING
-        # self.set_image(np.random.rand(100, 100))
+        self._image: np.ndarray | None = None
+        self._pixmap_item: QGraphicsPixmapItem | None = None
 
     @property
-    def image(self) -> Union[np.ndarray, None]:
+    def image(self) -> np.ndarray | None:
         return self._image
 
     @image.setter
@@ -563,7 +559,7 @@ class LineScanPlotWidget(PlotWidget):
         return self._pixmap_item
 
     @pixmap_item.setter
-    def pixmap_item(self, pixmap: Union[QPixmap, QGraphicsPixmapItem]) -> None:
+    def pixmap_item(self, pixmap: QPixmap | QGraphicsPixmapItem) -> None:
         if isinstance(pixmap, QPixmap) and self._pixmap_item is not None:
             # Replace the pixmap
             self._pixmap_item.setPixmap(pixmap)
@@ -585,7 +581,7 @@ class LineScanPlotWidget(PlotWidget):
             raise TypeError(f"Expected QPixmap or QGraphicsPixmapItem, got {type(pixmap)}")
 
     @property
-    def pixmap(self) -> Union[QPixmap, None]:
+    def pixmap(self) -> QPixmap | None:
         if self.pixmap_item is not None:
             return self.pixmap_item.pixmap()
         return None
@@ -614,8 +610,8 @@ class GrowthRatePlotWidget(PlotWidget):
         self,
         parent: FFTPlotWidget,
         popup: bool = False,
-        name: Optional[str] = None,
-        title: Optional[str] = None,
+        name: str | None = None,
+        title: str | None = None,
         show_menubar: bool = True,
     ) -> None:
         super().__init__(
@@ -632,7 +628,7 @@ class PlotGridWidget(QWidget):
 
     """ Widget for containing the live RHEED plots and plot transformations. """
 
-    def __init__(self, parent=None, title: Optional[str] = None, popup: bool = True):
+    def __init__(self, parent=None, title: str | None = None, popup: bool = True):
         super().__init__(parent)
         self._parent = parent
 

--- a/src/frheed/widgets/rheed_widgets.py
+++ b/src/frheed/widgets/rheed_widgets.py
@@ -2,8 +2,9 @@
 Widgets for RHEED analysis.
 """
 
+from __future__ import annotations
+
 import os
-from typing import Union
 
 from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtWidgets import QGridLayout, QMenuBar, QMessageBox, QSizePolicy, QWidget
@@ -154,7 +155,7 @@ class RHEEDWidget(QWidget):
                 self.region_plot.set_fft_max(color_data["time"][-1])
 
     @pyqtSlot(object)
-    def remove_line(self, shape: Union["CanvasShape", "CanvasLine"]) -> None:
+    def remove_line(self, shape: CanvasShape | CanvasLine) -> None:
         """Remove a line from the plot it is part of"""
         # Get the plot widget
         plot = self.profile_plot if shape.kind == "line" else self.region_plot
@@ -187,13 +188,3 @@ class RHEEDWidget(QWidget):
             os.startfile(path)
         except Exception as ex:
             QMessageBox.warning(self, "Error", f"Error opening {path}:\n{ex}")
-
-
-if __name__ == "__main__":
-
-    def test():
-        from frheed.utils import test_widget
-
-        return test_widget(RHEEDWidget, block=True)
-
-    widget, app = test()

--- a/src/frheed/widgets/selection_widgets.py
+++ b/src/frheed/widgets/selection_widgets.py
@@ -4,7 +4,6 @@ Widgets for selecting things, including the source camera to use.
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Union
 
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QGridLayout, QPushButton, QWidget
@@ -24,10 +23,10 @@ class CameraClasses(Enum):
 @dataclass
 class CameraObject:
     cam_class: object
-    src: Union[str, int]
-    name: Optional[str] = None
+    src: str | int
+    name: str | None = None
 
-    def get_camera(self) -> Union[FlirCamera, UsbCamera]:
+    def get_camera(self) -> FlirCamera | UsbCamera:
         return self.cam_class(src=self.src)
 
 
@@ -42,7 +41,7 @@ class CameraSelection(QWidget):
         # TODO: Apply global stylesheet
 
         # Reference to Camera object that will be instantiated later
-        self._cam: Union[FlirCamera, UsbCamera, None] = None
+        self._cam: FlirCamera | UsbCamera | None = None
 
         # Check for available cameras
         cams = self.available_cameras()
@@ -84,7 +83,7 @@ class CameraSelection(QWidget):
         # Show the widget
         self.setVisible(True)
 
-    def available_cameras(self) -> List[CameraObject]:
+    def available_cameras(self) -> list[CameraObject]:
         # Check each camera class for availability
         usb_cams = [CameraObject(UsbCamera, src, name) for src, name in get_usb_cams().items()]
         flir_cams = [CameraObject(FlirCamera, src, name) for src, name in get_flir_cams().items()]


### PR DESCRIPTION
Ban certain `typing` imports in favor of standard library features or other imports.

Fix `ruff` errors that occur due to the new rules.