### PR TITLE
Begin adding live image region calculations

### DIFF
--- a/src/frheed/image_util.py
+++ b/src/frheed/image_util.py
@@ -1,7 +1,5 @@
 """Image processing utilities."""
 
-import functools
-
 import cv2
 import numpy as np
 import numpy.typing as npt
@@ -10,12 +8,8 @@ from PyQt6 import QtGui
 ImageArray = npt.NDArray[np.generic]
 
 
-@functools.lru_cache
 def qimage_to_ndarray(image: QtGui.QImage) -> ImageArray:
-    """Converts a QImage to a numpy array.
-
-    This function is cached, so the resulting array should be copied before modifying it.
-    """
+    """Converts a QImage to a numpy array."""
     if (image_bits := image.bits()) is None:
         raise ValueError("Image contains no data")
 

--- a/src/frheed/image_util.py
+++ b/src/frheed/image_util.py
@@ -8,6 +8,24 @@ from PyQt6 import QtGui
 ImageArray = npt.NDArray[np.generic]
 
 
+def get_image_shape(image: ImageArray) -> tuple[int, int, int]:
+    """Returns the height, width, and number of channels of an image.
+
+    Raises:
+        TypeError if the image has less than 2 dimensions or greater than 3 dimensions.
+    """
+    match image.ndim:
+        case 2:
+            height, width = image.shape
+            channels = 1
+        case 3:
+            height, width, channels = image.shape
+        case _:
+            raise TypeError(f"Image with shape {image.shape} has unsupported number of dimensions")
+
+    return (height, width, channels)
+
+
 def qimage_to_ndarray(image: QtGui.QImage) -> ImageArray:
     """Converts a QImage to a numpy array."""
     if (image_bits := image.bits()) is None:
@@ -24,7 +42,9 @@ def qimage_to_ndarray(image: QtGui.QImage) -> ImageArray:
 
 def get_rectangle_region(image: ImageArray, x1: int, y1: int, x2: int, y2: int) -> ImageArray:
     """Returns the region of an image bound by a rectangle."""
-    return np.copy(image[y1:y2, x1:x2])
+    # The region must have nonzero dimensions
+    h, w = image.shape[:2]
+    return np.copy(image[min(y1, h - 2) : max(y2, y1 + 1), min(x1, w - 2) : max(x2, x1 + 1)])
 
 
 def get_ellipse_region(image: ImageArray, x1: int, y1: int, x2: int, y2: int) -> ImageArray:
@@ -32,11 +52,11 @@ def get_ellipse_region(image: ImageArray, x1: int, y1: int, x2: int, y2: int) ->
     # Get the region within the ellipse bounding box
     region = get_rectangle_region(image, x1, y1, x2, y2)
 
-    # Create an elliptical mask where 1 = pixel to include, 0 = pixel to exclude
-    height, width = region.shape[:2]
+    # Mask all pixels outside the ellipse
+    height, width, channels = get_image_shape(region)
     center_x = width // 2
     center_y = height // 2
-    mask = np.zeros((height, width), dtype=np.uint8)
+    mask = np.ones(region.shape, dtype=np.uint8)
     cv2.ellipse(
         mask,
         center=(center_x, center_y),
@@ -44,12 +64,10 @@ def get_ellipse_region(image: ImageArray, x1: int, y1: int, x2: int, y2: int) ->
         angle=0,
         startAngle=0,
         endAngle=360,
-        color=(1,),
+        color=[0] * channels,
         thickness=-1,  # negative thickness will draw a filled ellipse
     )
-
-    # Set all pixels outside the elliptical mask to 0
-    return cv2.bitwise_and(region, region, mask=mask)
+    return np.ma.MaskedArray(region, mask=np.ma.make_mask(mask))
 
 
 def get_line_region(
@@ -58,11 +76,12 @@ def get_line_region(
     """Returns the region of an image under a line."""
     # Get the region within the line bounding box
     region = get_rectangle_region(image, x1, y1, x2, y2)
+    if x1 == x2 or y1 == y2:
+        # Region is already a line and does not require masking
+        return region
 
-    # Create a mask by drawing the line
-    height, width = region.shape[:2]
-    mask = np.zeros((height, width), dtype=np.uint8)
-    cv2.line(region, pt1=(0, 0), pt2=(height, width), color=(1,), thickness=thickness)
-
-    # Set all pixels not under the line to 0
-    return cv2.bitwise_and(region, region, mask=mask)
+    # Mask all pixels not under the line
+    height, width, channels = get_image_shape(region)
+    mask = np.zeros(region.shape, dtype=np.uint8)
+    cv2.line(mask, pt1=(0, 0), pt2=(height, width), color=[0] * channels, thickness=thickness)
+    return np.ma.MaskedArray(region, mask=np.ma.make_mask(mask))

--- a/src/frheed/ui/camera.py
+++ b/src/frheed/ui/camera.py
@@ -6,6 +6,7 @@ import logging
 
 from PyQt6 import QtCore, QtGui, QtMultimedia, QtWidgets
 
+from frheed import image_util
 from frheed.ui import colormap, display
 
 
@@ -347,14 +348,9 @@ class CameraWidget(QtWidgets.QWidget):
         if image is None:
             return
 
+        image_array = image_util.qimage_to_ndarray(image)
         for shape in self.camera_display.shapes:
-            region = display.get_image_region(image, shape)
-
-            try:
-                print(
-                    f"{region.sum() = }, {region.mean() = }, {region.min() = }, {region.max() = }"
-                )
-                # print(f"{region = }")
-            except ValueError:
-                # Array is empty
-                pass
+            _region = display.get_image_region(image_array, shape)
+            # print(
+            #     f"{region.sum() = }, {region.mean() = }, {region.min() = }, {region.max() = }"
+            # )

--- a/src/frheed/ui/display.py
+++ b/src/frheed/ui/display.py
@@ -331,7 +331,8 @@ def get_image_region(
     if isinstance(image, QtGui.QImage):
         image = image_util.qimage_to_ndarray(image)
 
-    rect = shape.get_bounding_rect().toRect()
+    # The rectangle must have positive width and height to draw the region
+    rect = shape.get_bounding_rect().toRect().normalized()
     x1, y1, x2, y2 = rect.left(), rect.top(), rect.right(), rect.bottom()
     if isinstance(shape, Rectangle):
         return image_util.get_rectangle_region(image, x1, y1, x2, y2)

--- a/src/frheed/ui/display.py
+++ b/src/frheed/ui/display.py
@@ -9,6 +9,8 @@ import logging
 import attrs
 from PyQt6 import QtCore, QtGui, QtWidgets
 
+from frheed import image_util
+
 # The default pen width for all shapes
 SHAPE_PEN_WIDTH = 2
 
@@ -221,6 +223,7 @@ class Shape(QtWidgets.QGraphicsPathItem):
         return QtCore.QRectF(self.p1, self.p2)
 
     def set_bounding_rect(self, rect: QtCore.QRectF) -> None:
+        """Sets the bounding rectangle for the shape."""
         self.set_points(rect.topLeft(), rect.bottomRight())
 
     def update_bounding_box(self) -> None:
@@ -319,6 +322,25 @@ class Line(Shape):
         path.moveTo(p1)
         path.lineTo(p2)
         self.setPath(path)
+
+
+def get_image_region(
+    image: QtGui.QImage | image_util.ImageArray, shape: Shape
+) -> image_util.ImageArray:
+    """Returns the region of an image within a shape."""
+    if isinstance(image, QtGui.QImage):
+        image = image_util.qimage_to_ndarray(image)
+
+    rect = shape.get_bounding_rect().toRect()
+    x1, y1, x2, y2 = rect.left(), rect.top(), rect.right(), rect.bottom()
+    if isinstance(shape, Rectangle):
+        return image_util.get_rectangle_region(image, x1, y1, x2, y2)
+    elif isinstance(shape, Ellipse):
+        return image_util.get_ellipse_region(image, x1, y1, x2, y2)
+    elif isinstance(shape, Line):
+        return image_util.get_line_region(image, x1, y1, x2, y2)
+
+    raise ValueError(f"Cannot get region for shape with type {type(shape).__name__!r}")
 
 
 class ShapeHandle(QtWidgets.QGraphicsEllipseItem):

--- a/src/frheed/ui/display.py
+++ b/src/frheed/ui/display.py
@@ -327,7 +327,11 @@ class Line(Shape):
 def get_image_region(
     image: QtGui.QImage | image_util.ImageArray, shape: Shape
 ) -> image_util.ImageArray:
-    """Returns the region of an image within a shape."""
+    """Returns the region of an image within a shape.
+
+    Raises:
+        NotImplementedError if getting the image region is not implemented for the given shape type.
+    """
     if isinstance(image, QtGui.QImage):
         image = image_util.qimage_to_ndarray(image)
 
@@ -341,7 +345,9 @@ def get_image_region(
     elif isinstance(shape, Line):
         return image_util.get_line_region(image, x1, y1, x2, y2)
 
-    raise ValueError(f"Cannot get region for shape with type {type(shape).__name__!r}")
+    raise NotImplementedError(
+        f"Getting the image region is not implemented for shape type {type(shape).__name__!r}"
+    )
 
 
 class ShapeHandle(QtWidgets.QGraphicsEllipseItem):


### PR DESCRIPTION
Fix methods for extracting image regions to use masked arrays instead of plain arrays filled with a certain value, since filling with another value affects the statistics of that region.